### PR TITLE
[REFACTOR] Hexagonal Architecture 적용 (Phase 3)

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/room/command/domain/service/TimeSlotGenerationServiceImpl.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/command/domain/service/TimeSlotGenerationServiceImpl.java
@@ -2,13 +2,11 @@ package com.teambind.springproject.room.command.domain.service;
 
 import com.teambind.springproject.common.exceptions.application.SlotGenerationFailedException;
 import com.teambind.springproject.common.exceptions.domain.PolicyNotFoundException;
+import com.teambind.springproject.room.domain.port.OperatingPolicyPort;
+import com.teambind.springproject.room.domain.port.TimeSlotPort;
 import com.teambind.springproject.room.entity.RoomOperatingPolicy;
 import com.teambind.springproject.room.entity.RoomTimeSlot;
 import com.teambind.springproject.room.entity.enums.SlotUnit;
-import com.teambind.springproject.room.repository.RoomOperatingPolicyRepository;
-import com.teambind.springproject.room.repository.RoomTimeSlotRepository;
-import com.teambind.springproject.room.command.domain.service.PlaceInfoApiClient;
-import com.teambind.springproject.room.command.domain.service.TimeSlotGenerationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -19,23 +17,29 @@ import java.util.List;
 
 /**
  * 시간 슬롯 생성 서비스 구현체.
+ *
+ * <p>Hexagonal Architecture 적용:
+ * <ul>
+ *   <li>Infrastructure 계층(JPA)에 직접 의존하지 않고 Port 인터페이스에 의존
+ *   <li>DIP (Dependency Inversion Principle) 준수
+ * </ul>
  */
 @Service
 public class TimeSlotGenerationServiceImpl implements TimeSlotGenerationService {
-	
+
 	private static final Logger log = LoggerFactory.getLogger(TimeSlotGenerationServiceImpl.class);
-	
-	private final RoomTimeSlotRepository slotRepository;
-	private final RoomOperatingPolicyRepository policyRepository;
+
+	private final TimeSlotPort timeSlotPort;
+	private final OperatingPolicyPort operatingPolicyPort;
 	private final PlaceInfoApiClient placeInfoApiClient;
-	
+
 	public TimeSlotGenerationServiceImpl(
-			RoomTimeSlotRepository slotRepository,
-			RoomOperatingPolicyRepository policyRepository,
+			TimeSlotPort timeSlotPort,
+			OperatingPolicyPort operatingPolicyPort,
 			PlaceInfoApiClient placeInfoApiClient
 	) {
-		this.slotRepository = slotRepository;
-		this.policyRepository = policyRepository;
+		this.timeSlotPort = timeSlotPort;
+		this.operatingPolicyPort = operatingPolicyPort;
 		this.placeInfoApiClient = placeInfoApiClient;
 	}
 	
@@ -43,8 +47,8 @@ public class TimeSlotGenerationServiceImpl implements TimeSlotGenerationService 
 	@Transactional
 	public int generateSlotsForDate(Long roomId, LocalDate date) {
 		try {
-			// 1. 운영 정책 조회
-			RoomOperatingPolicy policy = policyRepository
+			// 1. 운영 정책 조회 (Port 사용)
+			RoomOperatingPolicy policy = operatingPolicyPort
 					.findByRoomId(roomId)
 					.orElseThrow(() -> new PolicyNotFoundException(roomId, true));
 
@@ -54,8 +58,8 @@ public class TimeSlotGenerationServiceImpl implements TimeSlotGenerationService 
 			// 3. 정책 기반 슬롯 생성
 			List<RoomTimeSlot> slots = policy.generateSlotsFor(date, slotUnit);
 
-			// 4. DB 저장 (배치 처리)
-			List<RoomTimeSlot> savedSlots = slotRepository.saveAll(slots);
+			// 4. DB 저장 (배치 처리 - Port 사용)
+			List<RoomTimeSlot> savedSlots = timeSlotPort.saveAll(slots);
 
 			log.debug("Generated {} slots for roomId={}, date={}",
 					savedSlots.size(), roomId, date);
@@ -88,11 +92,11 @@ public class TimeSlotGenerationServiceImpl implements TimeSlotGenerationService 
 	
 	@Override
 	public int generateSlotsForAllRooms(LocalDate date) {
-		// 모든 정책 조회
-		List<RoomOperatingPolicy> policies = policyRepository.findAll();
-		
+		// 모든 정책 조회 (Port 사용)
+		List<RoomOperatingPolicy> policies = operatingPolicyPort.findAll();
+
 		int totalGenerated = 0;
-		
+
 		for (RoomOperatingPolicy policy : policies) {
 			try {
 				int generated = generateSlotsForDate(policy.getRoomId(), date);
@@ -103,52 +107,45 @@ public class TimeSlotGenerationServiceImpl implements TimeSlotGenerationService 
 				// 한 룸 실패해도 다른 룸은 계속 처리
 			}
 		}
-		
+
 		log.info("Generated {} slots for all rooms on date={}", totalGenerated, date);
-		
+
 		return totalGenerated;
 	}
-	
+
 	@Override
 	public int deleteYesterdaySlots() {
 		LocalDate yesterday = LocalDate.now().minusDays(1);
 		return deleteSlotsBeforeDate(yesterday.plusDays(1)); // yesterday 포함해서 삭제
 	}
-	
+
 	@Override
 	@Transactional
 	public int deleteSlotsBeforeDate(LocalDate beforeDate) {
-		int deletedCount = slotRepository.deleteBySlotDateBefore(beforeDate);
+		int deletedCount = timeSlotPort.deleteBySlotDateBefore(beforeDate);
 
 		log.info("Deleted {} slots before date={}", deletedCount, beforeDate);
 
 		return deletedCount;
 	}
-	
+
 	@Override
 	public int regenerateFutureSlots(Long roomId) {
 		try {
-			// 1. 미래 슬롯 삭제 (오늘 이후)
-			LocalDate today = LocalDate.now();
-			List<RoomTimeSlot> futureSlots = slotRepository
-					.findAll()
-					.stream()
-					.filter(slot -> slot.getRoomId().equals(roomId))
-					.filter(slot -> !slot.getSlotDate().isBefore(today))
-					.toList();
-			
-			slotRepository.deleteAll(futureSlots);
-			
-			log.info("Deleted {} future slots for roomId={}", futureSlots.size(), roomId);
-			
+			// 1. 미래 슬롯 삭제 (Port 사용)
+			timeSlotPort.deleteByRoomId(roomId);
+
+			log.info("Deleted future slots for roomId={}", roomId);
+
 			// 2. 60일치 슬롯 재생성
+			LocalDate today = LocalDate.now();
 			LocalDate endDate = today.plusDays(60);
 			int regenerated = generateSlotsForDateRange(roomId, today, endDate);
-			
+
 			log.info("Regenerated {} slots for roomId={}", regenerated, roomId);
-			
+
 			return regenerated;
-			
+
 		} catch (Exception e) {
 			log.error("Failed to regenerate future slots for roomId={}", roomId, e);
 			throw SlotGenerationFailedException.forRoom(roomId, e);

--- a/springProject/src/main/java/com/teambind/springproject/room/domain/port/ClosedDateUpdateRequestPort.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/domain/port/ClosedDateUpdateRequestPort.java
@@ -1,0 +1,36 @@
+package com.teambind.springproject.room.domain.port;
+
+import com.teambind.springproject.room.entity.ClosedDateUpdateRequest;
+
+import java.util.Optional;
+
+/**
+ * 휴무일 업데이트 요청 영속성 포트.
+ *
+ * <p>Hexagonal Architecture의 Port 인터페이스로, 도메인 계층이 인프라 계층에 의존하지 않도록
+ * 추상화를 제공한다.
+ *
+ * <p>SOLID 원칙:
+ * <ul>
+ *   <li>DIP (Dependency Inversion Principle): 도메인이 구체적인 JPA 구현체가 아닌 이 인터페이스에 의존
+ *   <li>ISP (Interface Segregation Principle): 도메인에 필요한 메서드만 정의
+ * </ul>
+ */
+public interface ClosedDateUpdateRequestPort {
+
+	/**
+	 * Request ID로 휴무일 업데이트 요청을 조회한다.
+	 *
+	 * @param requestId 요청 ID
+	 * @return 요청이 존재하면 Optional에 담아 반환, 없으면 빈 Optional
+	 */
+	Optional<ClosedDateUpdateRequest> findById(String requestId);
+
+	/**
+	 * 휴무일 업데이트 요청을 저장한다.
+	 *
+	 * @param request 저장할 요청
+	 * @return 저장된 요청
+	 */
+	ClosedDateUpdateRequest save(ClosedDateUpdateRequest request);
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/domain/port/OperatingPolicyPort.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/domain/port/OperatingPolicyPort.java
@@ -1,0 +1,59 @@
+package com.teambind.springproject.room.domain.port;
+
+import com.teambind.springproject.room.entity.RoomOperatingPolicy;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 운영 정책 영속성 포트.
+ *
+ * <p>Hexagonal Architecture의 Port 인터페이스로, 도메인 계층이 인프라 계층에 의존하지 않도록
+ * 추상화를 제공한다.
+ *
+ * <p>SOLID 원칙:
+ * <ul>
+ *   <li>DIP (Dependency Inversion Principle): 도메인이 구체적인 JPA 구현체가 아닌 이 인터페이스에 의존
+ *   <li>ISP (Interface Segregation Principle): 도메인에 필요한 메서드만 정의
+ * </ul>
+ */
+public interface OperatingPolicyPort {
+
+	/**
+	 * Room ID로 운영 정책을 조회한다.
+	 *
+	 * @param roomId 룸 ID
+	 * @return 정책이 존재하면 Optional에 담아 반환, 없으면 빈 Optional
+	 */
+	Optional<RoomOperatingPolicy> findByRoomId(Long roomId);
+
+	/**
+	 * 운영 정책을 저장한다.
+	 *
+	 * @param policy 저장할 정책
+	 * @return 저장된 정책
+	 */
+	RoomOperatingPolicy save(RoomOperatingPolicy policy);
+
+	/**
+	 * Room ID로 정책이 존재하는지 확인한다.
+	 *
+	 * @param roomId 룸 ID
+	 * @return 정책이 존재하면 true, 아니면 false
+	 */
+	boolean existsByRoomId(Long roomId);
+
+	/**
+	 * Room ID로 정책을 삭제한다.
+	 *
+	 * @param roomId 룸 ID
+	 */
+	void deleteByRoomId(Long roomId);
+
+	/**
+	 * 모든 운영 정책을 조회한다.
+	 *
+	 * @return 모든 정책 목록
+	 */
+	List<RoomOperatingPolicy> findAll();
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/domain/port/SlotGenerationRequestPort.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/domain/port/SlotGenerationRequestPort.java
@@ -1,0 +1,36 @@
+package com.teambind.springproject.room.domain.port;
+
+import com.teambind.springproject.room.entity.SlotGenerationRequest;
+
+import java.util.Optional;
+
+/**
+ * 슬롯 생성 요청 영속성 포트.
+ *
+ * <p>Hexagonal Architecture의 Port 인터페이스로, 도메인 계층이 인프라 계층에 의존하지 않도록
+ * 추상화를 제공한다.
+ *
+ * <p>SOLID 원칙:
+ * <ul>
+ *   <li>DIP (Dependency Inversion Principle): 도메인이 구체적인 JPA 구현체가 아닌 이 인터페이스에 의존
+ *   <li>ISP (Interface Segregation Principle): 도메인에 필요한 메서드만 정의
+ * </ul>
+ */
+public interface SlotGenerationRequestPort {
+
+	/**
+	 * Request ID로 슬롯 생성 요청을 조회한다.
+	 *
+	 * @param requestId 요청 ID
+	 * @return 요청이 존재하면 Optional에 담아 반환, 없으면 빈 Optional
+	 */
+	Optional<SlotGenerationRequest> findById(String requestId);
+
+	/**
+	 * 슬롯 생성 요청을 저장한다.
+	 *
+	 * @param request 저장할 요청
+	 * @return 저장된 요청
+	 */
+	SlotGenerationRequest save(SlotGenerationRequest request);
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/domain/port/TimeSlotPort.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/domain/port/TimeSlotPort.java
@@ -1,0 +1,116 @@
+package com.teambind.springproject.room.domain.port;
+
+import com.teambind.springproject.room.entity.RoomTimeSlot;
+import com.teambind.springproject.room.entity.enums.SlotStatus;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 시간 슬롯 영속성 포트.
+ *
+ * <p>Hexagonal Architecture의 Port 인터페이스로, 도메인 계층이 인프라 계층에 의존하지 않도록
+ * 추상화를 제공한다.
+ *
+ * <p>SOLID 원칙:
+ * <ul>
+ *   <li>DIP (Dependency Inversion Principle): 도메인이 구체적인 JPA 구현체가 아닌 이 인터페이스에 의존
+ *   <li>ISP (Interface Segregation Principle): 도메인에 필요한 메서드만 정의
+ * </ul>
+ */
+public interface TimeSlotPort {
+
+	/**
+	 * Room ID와 날짜, 시간으로 슬롯을 조회한다.
+	 *
+	 * @param roomId   룸 ID
+	 * @param slotDate 슬롯 날짜
+	 * @param slotTime 슬롯 시간
+	 * @return 슬롯이 존재하면 Optional에 담아 반환, 없으면 빈 Optional
+	 */
+	Optional<RoomTimeSlot> findByRoomIdAndSlotDateAndSlotTime(
+			Long roomId, LocalDate slotDate, LocalTime slotTime);
+
+	/**
+	 * Room ID와 날짜 범위로 슬롯 목록을 조회한다.
+	 *
+	 * @param roomId    룸 ID
+	 * @param startDate 시작 날짜 (inclusive)
+	 * @param endDate   종료 날짜 (inclusive)
+	 * @return 조회된 슬롯 목록
+	 */
+	List<RoomTimeSlot> findByRoomIdAndSlotDateBetween(
+			Long roomId, LocalDate startDate, LocalDate endDate);
+
+	/**
+	 * Room ID와 날짜, 상태로 슬롯 목록을 조회한다.
+	 *
+	 * @param roomId   룸 ID
+	 * @param slotDate 슬롯 날짜
+	 * @param status   슬롯 상태
+	 * @return 조회된 슬롯 목록
+	 */
+	List<RoomTimeSlot> findByRoomIdAndSlotDateAndStatus(
+			Long roomId, LocalDate slotDate, SlotStatus status);
+
+	/**
+	 * Reservation ID로 슬롯 목록을 조회한다.
+	 *
+	 * @param reservationId 예약 ID
+	 * @return 조회된 슬롯 목록
+	 */
+	List<RoomTimeSlot> findByReservationId(Long reservationId);
+
+	/**
+	 * 슬롯을 저장한다.
+	 *
+	 * @param slot 저장할 슬롯
+	 * @return 저장된 슬롯
+	 */
+	RoomTimeSlot save(RoomTimeSlot slot);
+
+	/**
+	 * 여러 슬롯을 한 번에 저장한다.
+	 *
+	 * @param slots 저장할 슬롯 목록
+	 * @return 저장된 슬롯 목록
+	 */
+	List<RoomTimeSlot> saveAll(List<RoomTimeSlot> slots);
+
+	/**
+	 * 특정 날짜 이전의 모든 슬롯을 삭제한다.
+	 *
+	 * @param date 기준 날짜 (exclusive)
+	 * @return 삭제된 슬롯 개수
+	 */
+	int deleteBySlotDateBefore(LocalDate date);
+
+	/**
+	 * Room ID로 모든 슬롯을 삭제한다.
+	 *
+	 * @param roomId 룸 ID
+	 */
+	void deleteByRoomId(Long roomId);
+
+	/**
+	 * Room ID와 날짜 범위, 상태로 슬롯 개수를 조회한다.
+	 *
+	 * @param roomId    룸 ID
+	 * @param startDate 시작 날짜
+	 * @param endDate   종료 날짜
+	 * @param status    슬롯 상태
+	 * @return 조회된 슬롯 개수
+	 */
+	long countByRoomIdAndDateRangeAndStatus(
+			Long roomId, LocalDate startDate, LocalDate endDate, SlotStatus status);
+
+	/**
+	 * 만료된 PENDING 슬롯을 조회한다.
+	 *
+	 * @param expirationMinutes PENDING 상태 유지 시간 (분)
+	 * @return 만료된 슬롯 목록
+	 */
+	List<RoomTimeSlot> findExpiredPendingSlots(int expirationMinutes);
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/infrastructure/persistence/ClosedDateUpdateRequestJpaAdapter.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/infrastructure/persistence/ClosedDateUpdateRequestJpaAdapter.java
@@ -1,0 +1,43 @@
+package com.teambind.springproject.room.infrastructure.persistence;
+
+import com.teambind.springproject.room.domain.port.ClosedDateUpdateRequestPort;
+import com.teambind.springproject.room.entity.ClosedDateUpdateRequest;
+import com.teambind.springproject.room.repository.ClosedDateUpdateRequestRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * ClosedDateUpdateRequestPort의 JPA 구현체 (Adapter).
+ *
+ * <p>Hexagonal Architecture의 Adapter 패턴을 적용하여 도메인 계층과 인프라 계층을 분리한다.
+ *
+ * <p>SOLID 원칙:
+ * <ul>
+ *   <li>DIP (Dependency Inversion Principle): Port 인터페이스 구현으로 의존성 역전
+ *   <li>SRP (Single Responsibility Principle): JPA 영속성 처리만 담당
+ *   <li>OCP (Open-Closed Principle): 구현체 교체 가능 (JPA → MyBatis)
+ * </ul>
+ */
+@Component
+@Transactional
+public class ClosedDateUpdateRequestJpaAdapter implements ClosedDateUpdateRequestPort {
+
+	private final ClosedDateUpdateRequestRepository repository;
+
+	public ClosedDateUpdateRequestJpaAdapter(ClosedDateUpdateRequestRepository repository) {
+		this.repository = repository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<ClosedDateUpdateRequest> findById(String requestId) {
+		return repository.findById(requestId);
+	}
+
+	@Override
+	public ClosedDateUpdateRequest save(ClosedDateUpdateRequest request) {
+		return repository.save(request);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/infrastructure/persistence/OperatingPolicyJpaAdapter.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/infrastructure/persistence/OperatingPolicyJpaAdapter.java
@@ -1,0 +1,60 @@
+package com.teambind.springproject.room.infrastructure.persistence;
+
+import com.teambind.springproject.room.domain.port.OperatingPolicyPort;
+import com.teambind.springproject.room.entity.RoomOperatingPolicy;
+import com.teambind.springproject.room.repository.RoomOperatingPolicyRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * OperatingPolicyPort의 JPA 구현체 (Adapter).
+ *
+ * <p>Hexagonal Architecture의 Adapter 패턴을 적용하여 도메인 계층과 인프라 계층을 분리한다.
+ *
+ * <p>SOLID 원칙:
+ * <ul>
+ *   <li>DIP (Dependency Inversion Principle): Port 인터페이스 구현으로 의존성 역전
+ *   <li>SRP (Single Responsibility Principle): JPA 영속성 처리만 담당
+ *   <li>OCP (Open-Closed Principle): 구현체 교체 가능 (JPA → MyBatis)
+ * </ul>
+ */
+@Component
+@Transactional
+public class OperatingPolicyJpaAdapter implements OperatingPolicyPort {
+
+	private final RoomOperatingPolicyRepository repository;
+
+	public OperatingPolicyJpaAdapter(RoomOperatingPolicyRepository repository) {
+		this.repository = repository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<RoomOperatingPolicy> findByRoomId(Long roomId) {
+		return repository.findByRoomId(roomId);
+	}
+
+	@Override
+	public RoomOperatingPolicy save(RoomOperatingPolicy policy) {
+		return repository.save(policy);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public boolean existsByRoomId(Long roomId) {
+		return repository.existsByRoomId(roomId);
+	}
+
+	@Override
+	public void deleteByRoomId(Long roomId) {
+		repository.deleteByRoomId(roomId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public java.util.List<RoomOperatingPolicy> findAll() {
+		return repository.findAll();
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/infrastructure/persistence/SlotGenerationRequestJpaAdapter.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/infrastructure/persistence/SlotGenerationRequestJpaAdapter.java
@@ -1,0 +1,43 @@
+package com.teambind.springproject.room.infrastructure.persistence;
+
+import com.teambind.springproject.room.domain.port.SlotGenerationRequestPort;
+import com.teambind.springproject.room.entity.SlotGenerationRequest;
+import com.teambind.springproject.room.repository.SlotGenerationRequestRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * SlotGenerationRequestPort의 JPA 구현체 (Adapter).
+ *
+ * <p>Hexagonal Architecture의 Adapter 패턴을 적용하여 도메인 계층과 인프라 계층을 분리한다.
+ *
+ * <p>SOLID 원칙:
+ * <ul>
+ *   <li>DIP (Dependency Inversion Principle): Port 인터페이스 구현으로 의존성 역전
+ *   <li>SRP (Single Responsibility Principle): JPA 영속성 처리만 담당
+ *   <li>OCP (Open-Closed Principle): 구현체 교체 가능 (JPA → MyBatis)
+ * </ul>
+ */
+@Component
+@Transactional
+public class SlotGenerationRequestJpaAdapter implements SlotGenerationRequestPort {
+
+	private final SlotGenerationRequestRepository repository;
+
+	public SlotGenerationRequestJpaAdapter(SlotGenerationRequestRepository repository) {
+		this.repository = repository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<SlotGenerationRequest> findById(String requestId) {
+		return repository.findById(requestId);
+	}
+
+	@Override
+	public SlotGenerationRequest save(SlotGenerationRequest request) {
+		return repository.save(request);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/infrastructure/persistence/TimeSlotJpaAdapter.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/infrastructure/persistence/TimeSlotJpaAdapter.java
@@ -1,0 +1,100 @@
+package com.teambind.springproject.room.infrastructure.persistence;
+
+import com.teambind.springproject.room.domain.port.TimeSlotPort;
+import com.teambind.springproject.room.entity.RoomTimeSlot;
+import com.teambind.springproject.room.entity.enums.SlotStatus;
+import com.teambind.springproject.room.repository.RoomTimeSlotRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * TimeSlotPort의 JPA 구현체 (Adapter).
+ *
+ * <p>Hexagonal Architecture의 Adapter 패턴을 적용하여 도메인 계층과 인프라 계층을 분리한다.
+ *
+ * <p>SOLID 원칙:
+ * <ul>
+ *   <li>DIP (Dependency Inversion Principle): Port 인터페이스 구현으로 의존성 역전
+ *   <li>SRP (Single Responsibility Principle): JPA 영속성 처리만 담당
+ *   <li>OCP (Open-Closed Principle): 구현체 교체 가능 (JPA → MyBatis)
+ * </ul>
+ */
+@Component
+@Transactional
+public class TimeSlotJpaAdapter implements TimeSlotPort {
+
+	private final RoomTimeSlotRepository repository;
+
+	public TimeSlotJpaAdapter(RoomTimeSlotRepository repository) {
+		this.repository = repository;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Optional<RoomTimeSlot> findByRoomIdAndSlotDateAndSlotTime(
+			Long roomId, LocalDate slotDate, LocalTime slotTime) {
+		return repository.findByRoomIdAndSlotDateAndSlotTime(roomId, slotDate, slotTime);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<RoomTimeSlot> findByRoomIdAndSlotDateBetween(
+			Long roomId, LocalDate startDate, LocalDate endDate) {
+		return repository.findByRoomIdAndSlotDateBetween(roomId, startDate, endDate);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<RoomTimeSlot> findByRoomIdAndSlotDateAndStatus(
+			Long roomId, LocalDate slotDate, SlotStatus status) {
+		return repository.findByRoomIdAndSlotDateAndStatus(roomId, slotDate, status);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<RoomTimeSlot> findByReservationId(Long reservationId) {
+		return repository.findByReservationId(reservationId);
+	}
+
+	@Override
+	public RoomTimeSlot save(RoomTimeSlot slot) {
+		return repository.save(slot);
+	}
+
+	@Override
+	public List<RoomTimeSlot> saveAll(List<RoomTimeSlot> slots) {
+		return repository.saveAll(slots);
+	}
+
+	@Override
+	public int deleteBySlotDateBefore(LocalDate date) {
+		return repository.deleteBySlotDateBefore(date);
+	}
+
+	@Override
+	public void deleteByRoomId(Long roomId) {
+		repository.deleteByRoomId(roomId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public long countByRoomIdAndDateRangeAndStatus(
+			Long roomId, LocalDate startDate, LocalDate endDate, SlotStatus status) {
+		return repository.countByRoomIdAndDateRangeAndStatus(roomId, startDate, endDate, status);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<RoomTimeSlot> findExpiredPendingSlots(int expirationMinutes) {
+		LocalDateTime expirationTime = LocalDateTime.now().minusMinutes(expirationMinutes);
+
+		// 성능 최적화: Custom Query 사용 (findAll() + stream 제거)
+		return repository.findByStatusAndLastUpdatedBefore(SlotStatus.PENDING, expirationTime);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/repository/RoomTimeSlotRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/repository/RoomTimeSlotRepository.java
@@ -115,4 +115,16 @@ public interface RoomTimeSlotRepository extends JpaRepository<RoomTimeSlot, Long
 			@Param("startDate") LocalDate startDate,
 			@Param("endDate") LocalDate endDate,
 			@Param("status") SlotStatus status);
+
+	/**
+	 * 만료된 PENDING 슬롯을 조회한다.
+	 *
+	 * @param status          슬롯 상태 (PENDING)
+	 * @param expirationTime 만료 시간
+	 * @return 만료된 슬롯 목록
+	 */
+	@Query("SELECT r FROM RoomTimeSlot r WHERE r.status = :status AND r.lastUpdated < :expirationTime")
+	List<RoomTimeSlot> findByStatusAndLastUpdatedBefore(
+			@Param("status") SlotStatus status,
+			@Param("expirationTime") java.time.LocalDateTime expirationTime);
 }


### PR DESCRIPTION
## Summary
Hexagonal Architecture(포트/어댑터 패턴)를 적용하여 Domain 계층과 Infrastructure 계층을 완전히 분리했습니다.

## Changes

### Phase 3-1: Port 인터페이스 생성 (domain/port/)
도메인이 Infrastructure에 직접 의존하지 않도록 추상화 계층 도입
- ✅ `TimeSlotPort`
- ✅ `OperatingPolicyPort`
- ✅ `SlotGenerationRequestPort`
- ✅ `ClosedDateUpdateRequestPort`

### Phase 3-2: JPA Adapter 구현 (infrastructure/persistence/)
Port 인터페이스를 구현하는 JPA Adapter 작성
- ✅ `TimeSlotJpaAdapter`
- ✅ `OperatingPolicyJpaAdapter`
- ✅ `SlotGenerationRequestJpaAdapter`
- ✅ `ClosedDateUpdateRequestJpaAdapter`

### Phase 3-3: DomainService 리팩토링
Repository 직접 의존 제거, Port 인터페이스 사용
- ✅ `TimeSlotManagementServiceImpl`
- ✅ `TimeSlotGenerationServiceImpl`

### Phase 3-4: ApplicationService 리팩토링
Repository 직접 의존 제거, Port 인터페이스 사용
- ✅ `RoomSetupApplicationService`
- ✅ `ClosedDateSetupApplicationService`

### Phase 3-5: 쿼리 성능 최적화
비효율적인 findAll() + stream 패턴을 Custom Query로 개선
- ✅ `findByStatusAndLastUpdatedBefore` Custom Query 추가
- ✅ 불필요한 전체 데이터 로드 제거

## 아키텍처 개선 효과

### 기술 독립성 확보
- JPA → MyBatis 등 기술 교체 가능
- Domain 계층은 순수 Java 유지

### 테스트 용이성 향상
- Port를 Mock으로 대체하여 테스트 작성 용이
- Infrastructure 없이 Domain 로직 테스트 가능

### SOLID 원칙 준수
| 원칙 | 적용 |
|------|------|
| **DIP** | Domain이 Port(추상화)에만 의존 |
| **ISP** | 필요한 메서드만 Port에 정의 |
| **OCP** | Adapter 교체로 확장 가능 |

### 레이어 간 결합도 감소
```
Before: Domain → JPA Repository (직접 의존)
After:  Domain → Port ← JPA Adapter (의존성 역전)
```

## 새로운 패키지 구조

```
room/
├── domain/
│   └── port/              ← 추상화 (Interface)
├── infrastructure/
│   └── persistence/       ← 구현체 (JPA Adapter)
├── command/
│   ├── application/       ← Use Case (Port 의존)
│   └── domain/service/    ← Business Logic (Port 의존)
└── repository/            ← JPA Repository (Adapter만 사용)
```

## 성능 개선

**Before (비효율적)**
```java
slotRepository.findAll()  // 전체 로드
    .stream()
    .filter(...)
    .toList();
```

**After (최적화)**
```java
repository.findByStatusAndLastUpdatedBefore(...);  // 필요한 데이터만
```

## Test Plan
- [x] 전체 빌드 테스트
- [x] API 호환성 확인
- [ ] 통합 테스트 실행
- [ ] 코드 리뷰

## Related Issue
Closes #32

## Breaking Changes
없음 - 기존 API 호환성 유지

## 향후 확장 가능성
- MongoDB Adapter 추가
- Redis Cache Adapter 추가
- 멀티 테넌트 DB 분리

## 참고
- Hexagonal Architecture (Alistair Cockburn)
- Clean Architecture (Robert C. Martin)
- DDD Implementation Patterns