### PR TITLE
[CONFIG] 예약 가능 기간을 외부 설정으로 변경 (60일 → 30일)

### DIFF
--- a/springProject/src/main/resources/application.yaml
+++ b/springProject/src/main/resources/application.yaml
@@ -16,3 +16,5 @@ room:
     pending:
       expiration:
         minutes: 30
+    rollingWindow:
+      days: ${ROLLING_WINDOW_DAYS:30}

--- a/springProject/src/test/resources/application.yaml
+++ b/springProject/src/test/resources/application.yaml
@@ -43,3 +43,11 @@ external:
       url: http://localhost:8081
       connect-timeout: 5000
       read-timeout: 5000
+
+room:
+  timeSlot:
+    pending:
+      expiration:
+        minutes: 30
+    rollingWindow:
+      days: 30


### PR DESCRIPTION
## Summary
- TimeSlotScheduler의 하드코딩된 Rolling Window 기간(60일)을 외부 설정으로 분리
- 기본값을 30일로 변경하여 DB 부하 감소
- 환경 변수를 통한 동적 설정 지원으로 유연한 운영 가능

## Changes
### 1. TimeSlotScheduler.java
- `@Value("${room.timeSlot.rollingWindow.days}")` 어노테이션을 통한 설정값 주입
- `maintainRollingWindow()` 메서드에서 하드코딩된 60 제거
- JavaDoc 주석 업데이트 (60일 → N일, 기본 30일)
- 로그에 현재 설정값 출력 추가

### 2. application.yaml
- `room.timeSlot.rollingWindow.days` 설정 추가
- 환경 변수 `ROLLING_WINDOW_DAYS` 지원 (기본값: 30)

### 3. test/resources/application.yaml
- 테스트 환경에도 동일 설정 추가 (30일)

## Technical Details
- **Rolling Window**: 매일 새벽 2시 스케줄러 실행 시 어제 슬롯 삭제 + N일 후 슬롯 생성
- **기존**: 60일치 슬롯 유지 (약 2개월)
- **변경**: 30일치 슬롯 유지 (약 1개월) → DB 저장 공간 50% 절감
- **운영**: 환경 변수 `ROLLING_WINDOW_DAYS=45` 설정 시 45일로 동작

## Benefits
✅ 외부 설정을 통한 유연한 운영  
✅ DB 부하 감소 (슬롯 데이터 50% 절감)  
✅ 비즈니스 요구사항 반영 (30일 예약 정책)  
✅ 재배포 없이 설정 변경 가능  

## Test plan
- [x] 컴파일 테스트 통과
- [ ] 로컬 환경에서 스케줄러 동작 확인
- [ ] 환경 변수 ROLLING_WINDOW_DAYS 값 변경 테스트
- [ ] 스테이징 환경 배포 후 모니터링

## Related Issue
향후 예약 가능 기간 제한 기능 구현을 위한 기반 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)