### PR TITLE
[REFACTOR] Remove external API dependency for SlotUnit

### DIFF
--- a/springProject/Dockerfile
+++ b/springProject/Dockerfile
@@ -1,0 +1,41 @@
+# Stage 1: Build
+FROM gradle:8.5-jdk21 AS build
+
+WORKDIR /app
+
+# Copy Gradle files
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+
+# Copy source code
+COPY src ./src
+
+# Build the application
+RUN gradle clean bootJar --no-daemon
+
+# Stage 2: Runtime
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+# Create non-root user
+RUN groupadd -r spring && useradd -r -g spring spring
+
+# Copy built JAR from build stage
+COPY --from=build /app/build/libs/*.jar app.jar
+
+# Change ownership
+RUN chown -R spring:spring /app
+
+# Switch to non-root user
+USER spring:spring
+
+# Expose application port
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:8080/actuator/health || exit 1
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/springProject/build.gradle
+++ b/springProject/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // MariaDB driver
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
     // ShedLock for distributed scheduler lock
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.10.0'

--- a/springProject/src/main/java/com/teambind/springproject/room/command/application/RoomSetupApplicationService.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/command/application/RoomSetupApplicationService.java
@@ -96,6 +96,7 @@ public class RoomSetupApplicationService {
 				request.getRoomId(),
 				weeklySchedule,
 				recurrencePattern,
+				request.getSlotUnit(), // 클라이언트가 제공한 slotUnit 사용
 				Collections.emptyList() // 초기 설정 시 휴무일 없음
 		);
 		operatingPolicyPort.save(policy);

--- a/springProject/src/main/java/com/teambind/springproject/room/command/dto/RoomOperatingPolicySetupRequest.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/command/dto/RoomOperatingPolicySetupRequest.java
@@ -1,5 +1,6 @@
 package com.teambind.springproject.room.command.dto;
 
+import com.teambind.springproject.room.entity.enums.SlotUnit;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,14 +16,19 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RoomOperatingPolicySetupRequest {
-	
+
 	/**
 	 * 룸 ID
 	 */
 	private Long roomId;
-	
+
 	/**
 	 * 요일별 슬롯 시작 시각 목록 (각 슬롯에 recurrencePattern 포함)
 	 */
 	private List<WeeklySlotDto> slots;
+
+	/**
+	 * 슬롯 단위 (HOUR: 1시간, HALF_HOUR: 30분)
+	 */
+	private SlotUnit slotUnit;
 }

--- a/springProject/src/main/java/com/teambind/springproject/room/entity/RoomOperatingPolicy.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/entity/RoomOperatingPolicy.java
@@ -47,7 +47,11 @@ public class RoomOperatingPolicy {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private RecurrencePattern recurrence;
-	
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "slot_unit", nullable = false)
+	private SlotUnit slotUnit;
+
 	@ElementCollection
 	@CollectionTable(name = "policy_closed_dates", joinColumns = @JoinColumn(name = "policy_id"))
 	private List<ClosedDateRange> closedDates = new ArrayList<>();
@@ -66,22 +70,25 @@ public class RoomOperatingPolicy {
 			Long roomId,
 			WeeklySlotSchedule weeklySchedule,
 			RecurrencePattern recurrence,
+			SlotUnit slotUnit,
 			List<ClosedDateRange> closedDates) {
 		this.roomId = Objects.requireNonNull(roomId, "roomId must not be null");
 		this.weeklySchedule =
 				Objects.requireNonNull(weeklySchedule, "weeklySchedule must not be null");
 		this.recurrence = Objects.requireNonNull(recurrence, "recurrence must not be null");
+		this.slotUnit = Objects.requireNonNull(slotUnit, "slotUnit must not be null");
 		this.closedDates = new ArrayList<>(closedDates);
 		this.createdAt = LocalDateTime.now();
 		this.updatedAt = LocalDateTime.now();
 	}
-	
+
 	/**
 	 * RoomOperatingPolicy 인스턴스를 생성한다.
 	 *
 	 * @param roomId         룸 ID
 	 * @param weeklySchedule 주간 운영 시간 스케줄
 	 * @param recurrence     반복 패턴
+	 * @param slotUnit       슬롯 단위
 	 * @param closedDates    휴무일 목록
 	 * @return 생성된 RoomOperatingPolicy
 	 */
@@ -89,8 +96,9 @@ public class RoomOperatingPolicy {
 			Long roomId,
 			WeeklySlotSchedule weeklySchedule,
 			RecurrencePattern recurrence,
+			SlotUnit slotUnit,
 			List<ClosedDateRange> closedDates) {
-		return new RoomOperatingPolicy(roomId, weeklySchedule, recurrence, closedDates);
+		return new RoomOperatingPolicy(roomId, weeklySchedule, recurrence, slotUnit, closedDates);
 	}
 	
 	/**
@@ -259,7 +267,11 @@ public class RoomOperatingPolicy {
 	public RecurrencePattern getRecurrence() {
 		return recurrence;
 	}
-	
+
+	public SlotUnit getSlotUnit() {
+		return slotUnit;
+	}
+
 	public List<ClosedDateRange> getClosedDates() {
 		return Collections.unmodifiableList(closedDates);
 	}

--- a/springProject/src/main/java/com/teambind/springproject/room/event/event/SlotReservedEvent.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/event/event/SlotReservedEvent.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 /**
  * 슬롯 예약 대기 이벤트.
- * <p>
+ *
  * 여러 슬롯이 AVAILABLE → PENDING 상태로 전환될 때 발행된다.
  * 하나의 예약(reservationId)에 대해 여러 시간대의 슬롯을 예약할 수 있다.
  */

--- a/springProject/src/main/resources/application-prod.yaml
+++ b/springProject/src/main/resources/application-prod.yaml
@@ -1,0 +1,87 @@
+spring:
+  kafka:
+    bootstrap-servers:
+      - ${KAFKA_BROKER1:-kafka1:9091}
+      - ${KAFKA_BROKER2:-kafka2:9092}
+      - ${KAFKA_BROKER3:-kafka3:9093}
+    producer:
+      retries: 3
+      batch-size: 16384
+      buffer-memory: 33554432
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      compression-type: snappy
+    consumer:
+      group-id: room-operation-consumer-group-prod
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      enable-auto-commit: false
+      max-poll-records: 100
+    listener:
+      ack-mode: manual
+
+  datasource:
+    url: jdbc:mariadb://${DATABASE_HOST:-mariadb}:${DATABASE_PORT:-3306}/${DATABASE_NAME:-profiles}?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8mb4
+    username: ${DATABASE_USER_NAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+    hikari:
+      connection-timeout: 30000
+      maximum-pool-size: 20
+      minimum-idle: 10
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      auto-commit: true
+      connection-test-query: SELECT 1
+
+  jpa:
+    show-sql: false
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: false
+        dialect: org.hibernate.dialect.MariaDBDialect
+        jdbc:
+          time_zone: Asia/Seoul
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
+        batch_versioned_data: true
+        default_batch_fetch_size: 100
+
+  data:
+    redis:
+      repositories:
+        enabled: false
+      host: ${REDIS_HOST:-redis}
+      port: ${REDIS_PORT:-6379}
+      password: ${REDIS_PASSWORD:#{null}}
+      timeout: 3000ms
+      lettuce:
+        pool:
+          max-active: 20
+          max-idle: 10
+          min-idle: 5
+          max-wait: 2000ms
+
+  sql:
+    init:
+      mode: never
+
+# Logging Configuration
+logging:
+  level:
+    root: ${LOG_LEVEL:-INFO}
+    com.teambind: ${LOG_LEVEL:-INFO}
+    org.springframework: WARN
+    org.hibernate.SQL: ${SQL_LOG_LEVEL:-WARN}
+    org.hibernate.type.descriptor.sql: WARN
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+  file:
+    name: /var/log/room-service/application.log
+    max-size: 10MB
+    max-history: 30

--- a/springProject/src/main/resources/application.yaml
+++ b/springProject/src/main/resources/application.yaml
@@ -5,12 +5,6 @@ spring:
 server:
   port: ${SERVER_PORT:8080}
 
-external:
-  api:
-    place-info:
-      url: ${PLACE_INFO_API_URL:http://localhost:8081}
-      connect-timeout: ${PLACE_INFO_API_CONNECT_TIMEOUT:5000}
-      read-timeout: ${PLACE_INFO_API_READ_TIMEOUT:5000}
 room:
   timeSlot:
     pending:

--- a/springProject/src/test/java/com/teambind/springproject/room/entity/RoomOperatingPolicyTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/room/entity/RoomOperatingPolicyTest.java
@@ -72,7 +72,7 @@ class RoomOperatingPolicyTest {
 	
 	private RoomOperatingPolicy createBasicPolicy(RecurrencePattern recurrence) {
 		return RoomOperatingPolicy.create(
-				101L, createWeekdaySchedule(), recurrence, Collections.emptyList());
+				101L, createWeekdaySchedule(), recurrence, SlotUnit.HALF_HOUR, Collections.emptyList());
 	}
 	
 	// ============================================================
@@ -82,7 +82,7 @@ class RoomOperatingPolicyTest {
 	private RoomOperatingPolicy createPolicyWithClosedDate(
 			RecurrencePattern recurrence, ClosedDateRange closedDate) {
 		return RoomOperatingPolicy.create(
-				101L, createWeekdaySchedule(), recurrence, List.of(closedDate));
+				101L, createWeekdaySchedule(), recurrence, SlotUnit.HALF_HOUR, List.of(closedDate));
 	}
 	
 	// ============================================================


### PR DESCRIPTION
## 관련 이슈
Closes #44

## 변경 사항
- `RoomOperatingPolicySetupRequest`에 `slotUnit` 필드 추가
- `RoomOperatingPolicy` 엔티티에 `slotUnit` 컬럼 추가 및 getter 구현
- `TimeSlotGenerationServiceImpl`에서 `PlaceInfoApiClient` 의존성 제거
- 슬롯 생성 시 정책에 저장된 `slotUnit` 사용
- `build.gradle`에 MariaDB 드라이버 추가

## 변경 이유
요구사항 변경으로 운영시간 등록 시 외부 API 호출 없이 클라이언트로부터 시작시각 리스트와 슬롯 단위를 직접 받는 방식으로 변경됨

## 주요 변경 파일
- `RoomOperatingPolicySetupRequest.java` - slotUnit 필드 추가
- `RoomOperatingPolicy.java` - slotUnit 저장 및 조회
- `RoomSetupApplicationService.java` - 클라이언트 제공 slotUnit 사용
- `TimeSlotGenerationServiceImpl.java` - PlaceInfoApiClient 제거, 정책의 slotUnit 사용
- `build.gradle` - MariaDB 드라이버 추가

## 테스트
- [x] 기존 테스트 코드 일부 수정 완료
- [ ] 나머지 테스트 코드 수정 필요 (CI에서 확인 예정)

## 체크리스트
- [x] 코드 변경 완료
- [x] 주요 테스트 파일 수정
- [x] 커밋 메시지 작성
- [ ] 전체 테스트 통과 확인