### PR TITLE
Kafka 이벤트 ID 필드 String 변환 및 JsonUtil 개선

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/common/util/json/JsonUtilWithObjectMapper.java
+++ b/springProject/src/main/java/com/teambind/springproject/common/util/json/JsonUtilWithObjectMapper.java
@@ -1,12 +1,22 @@
 package com.teambind.springproject.common.util.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.stereotype.Component;
 
 @Component("jsonUtilWithObjectMapper")
 public class JsonUtilWithObjectMapper implements JsonUtil {
-	private final ObjectMapper objectMapper = new ObjectMapper();
-	
+	private final ObjectMapper objectMapper;
+
+	public JsonUtilWithObjectMapper() {
+		this.objectMapper = new ObjectMapper();
+		// Java 8 날짜/시간 타입 지원 활성화
+		this.objectMapper.registerModule(new JavaTimeModule());
+		// 날짜를 타임스탬프가 아닌 ISO-8601 문자열로 직렬화
+		this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	}
+
 	public String toJson(Object object) {
 		try {
 			return objectMapper.writeValueAsString(object);
@@ -14,7 +24,7 @@ public class JsonUtilWithObjectMapper implements JsonUtil {
 			throw new RuntimeException(e);
 		}
 	}
-	
+
 	public <T> T fromJson(String json, Class<T> clazz) {
 		try {
 			return objectMapper.readValue(json, clazz);

--- a/springProject/src/main/java/com/teambind/springproject/message/consume/EventConsumer.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/consume/EventConsumer.java
@@ -2,9 +2,9 @@ package com.teambind.springproject.message.consume;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teambind.springproject.message.dto.*;
 import com.teambind.springproject.message.event.Event;
 import com.teambind.springproject.message.handler.EventHandler;
-import com.teambind.springproject.room.event.event.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -23,21 +23,21 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 public class EventConsumer {
-	
-	private static final Map<String, Class<? extends Event>> EVENT_TYPE_MAP = new HashMap<>();
-	
+
+	private static final Map<String, Class<?>> MESSAGE_TYPE_MAP = new HashMap<>();
+
 	static {
-		EVENT_TYPE_MAP.put("SlotReserved", SlotReservedEvent.class);
-		EVENT_TYPE_MAP.put("SlotConfirmed", SlotConfirmedEvent.class);
-		EVENT_TYPE_MAP.put("SlotCancelled", SlotCancelledEvent.class);
-		EVENT_TYPE_MAP.put("SlotRestored", SlotRestoredEvent.class);
-		EVENT_TYPE_MAP.put("SlotGenerationRequested", SlotGenerationRequestedEvent.class);
-		EVENT_TYPE_MAP.put("ClosedDateUpdateRequested", ClosedDateUpdateRequestedEvent.class);
+		MESSAGE_TYPE_MAP.put("SlotReserved", SlotReservedEventMessage.class);
+		MESSAGE_TYPE_MAP.put("SlotConfirmed", SlotConfirmedEventMessage.class);
+		MESSAGE_TYPE_MAP.put("SlotCancelled", SlotCancelledEventMessage.class);
+		MESSAGE_TYPE_MAP.put("SlotRestored", SlotRestoredEventMessage.class);
+		MESSAGE_TYPE_MAP.put("SlotGenerationRequested", SlotGenerationRequestedEventMessage.class);
+		MESSAGE_TYPE_MAP.put("ClosedDateUpdateRequested", ClosedDateUpdateRequestedEventMessage.class);
 	}
-	
+
 	private final List<EventHandler<? extends Event>> eventHandlers;
 	private final ObjectMapper objectMapper;
-	
+
 	/**
 	 * Kafka에서 이벤트를 수신하여 처리한다.
 	 *
@@ -52,37 +52,62 @@ public class EventConsumer {
 			// 1. JSON에서 eventType 추출
 			JsonNode jsonNode = objectMapper.readTree(message);
 			String eventType = jsonNode.get("eventType").asText();
-			
+
 			log.info("Received event: type={}", eventType);
-			
-			// 2. eventType에 해당하는 클래스 찾기
-			Class<? extends Event> eventClass = EVENT_TYPE_MAP.get(eventType);
-			if (eventClass == null) {
+
+			// 2. eventType에 해당하는 Message DTO 클래스 찾기
+			Class<?> messageClass = MESSAGE_TYPE_MAP.get(eventType);
+			if (messageClass == null) {
 				log.error("Unknown event type: {}", eventType);
 				return;
 			}
-			
-			// 3. JSON을 이벤트 객체로 역직렬화
-			Event event = objectMapper.readValue(message, eventClass);
-			
-			// 4. 해당 이벤트를 처리할 핸들러 찾기
+
+			// 3. JSON을 Message DTO로 역직렬화 (ID: String)
+			Object messageDto = objectMapper.readValue(message, messageClass);
+
+			// 4. Message DTO를 Event로 변환 (ID: String → Long)
+			Event event = convertToEvent(messageDto);
+
+			// 5. 해당 이벤트를 처리할 핸들러 찾기
 			EventHandler handler = findHandler(eventType);
 			if (handler == null) {
 				log.warn("No handler found for event type: {}", eventType);
 				return;
 			}
-			
-			// 5. 핸들러로 이벤트 처리 위임
+
+			// 6. 핸들러로 이벤트 처리 위임
 			handler.handle(event);
-			
+
 			log.info("Event processed successfully: type={}", eventType);
-			
+
 		} catch (Exception e) {
 			log.error("Failed to process event: {}", message, e);
 			// TODO: 에러 처리 전략 (DLQ 전송, 재시도 등)
 		}
 	}
-	
+
+	/**
+	 * Message DTO를 Event로 변환한다.
+	 * 모든 ID 필드가 String → Long으로 변환된다.
+	 */
+	private Event convertToEvent(Object messageDto) {
+		if (messageDto instanceof SlotReservedEventMessage) {
+			return ((SlotReservedEventMessage) messageDto).toEvent();
+		} else if (messageDto instanceof SlotConfirmedEventMessage) {
+			return ((SlotConfirmedEventMessage) messageDto).toEvent();
+		} else if (messageDto instanceof SlotCancelledEventMessage) {
+			return ((SlotCancelledEventMessage) messageDto).toEvent();
+		} else if (messageDto instanceof SlotRestoredEventMessage) {
+			return ((SlotRestoredEventMessage) messageDto).toEvent();
+		} else if (messageDto instanceof SlotGenerationRequestedEventMessage) {
+			return ((SlotGenerationRequestedEventMessage) messageDto).toEvent();
+		} else if (messageDto instanceof ClosedDateUpdateRequestedEventMessage) {
+			return ((ClosedDateUpdateRequestedEventMessage) messageDto).toEvent();
+		}
+
+		throw new IllegalArgumentException("Unknown message type: " + messageDto.getClass().getName());
+	}
+
 	/**
 	 * 이벤트 타입에 맞는 핸들러를 찾는다.
 	 *

--- a/springProject/src/main/java/com/teambind/springproject/message/dto/ClosedDateUpdateRequestedEventMessage.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/dto/ClosedDateUpdateRequestedEventMessage.java
@@ -1,0 +1,51 @@
+package com.teambind.springproject.message.dto;
+
+import com.teambind.springproject.room.event.event.ClosedDateUpdateRequestedEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 휴무일 업데이트 요청 이벤트 메시지 DTO.
+ * <p>
+ * Kafka 메시지로 전송될 때 사용되며, 모든 ID 필드는 String으로 직렬화된다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ClosedDateUpdateRequestedEventMessage {
+
+	private String topic;
+	private String eventType;
+	private String requestId;
+	private String roomId;
+	private LocalDateTime requestedAt;
+
+	/**
+	 * ClosedDateUpdateRequestedEvent로부터 메시지 DTO를 생성한다.
+	 * Long ID → String ID 변환
+	 */
+	public static ClosedDateUpdateRequestedEventMessage from(ClosedDateUpdateRequestedEvent event) {
+		return new ClosedDateUpdateRequestedEventMessage(
+				event.getTopic(),
+				event.getEventType(),
+				event.getRequestId(),
+				event.getRoomId() != null ? event.getRoomId().toString() : null,
+				event.getRequestedAt()
+		);
+	}
+
+	/**
+	 * 메시지 DTO를 ClosedDateUpdateRequestedEvent로 변환한다.
+	 * String ID → Long ID 변환
+	 */
+	public ClosedDateUpdateRequestedEvent toEvent() {
+		return ClosedDateUpdateRequestedEvent.of(
+				requestId,
+				roomId != null ? Long.parseLong(roomId) : null
+		);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/message/dto/SlotCancelledEventMessage.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/dto/SlotCancelledEventMessage.java
@@ -1,0 +1,51 @@
+package com.teambind.springproject.message.dto;
+
+import com.teambind.springproject.room.event.event.SlotCancelledEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 슬롯 취소 이벤트 메시지 DTO.
+ * <p>
+ * Kafka 메시지로 전송될 때 사용되며, 모든 ID 필드는 String으로 직렬화된다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SlotCancelledEventMessage {
+
+	private String topic;
+	private String eventType;
+	private String reservationId;
+	private String cancelReason;
+	private LocalDateTime occurredAt;
+
+	/**
+	 * SlotCancelledEvent로부터 메시지 DTO를 생성한다.
+	 * Long ID → String ID 변환
+	 */
+	public static SlotCancelledEventMessage from(SlotCancelledEvent event) {
+		return new SlotCancelledEventMessage(
+				event.getTopic(),
+				event.getEventType(),
+				event.getReservationId() != null ? event.getReservationId().toString() : null,
+				event.getCancelReason(),
+				event.getOccurredAt()
+		);
+	}
+
+	/**
+	 * 메시지 DTO를 SlotCancelledEvent로 변환한다.
+	 * String ID → Long ID 변환
+	 */
+	public SlotCancelledEvent toEvent() {
+		return SlotCancelledEvent.of(
+				reservationId != null ? Long.parseLong(reservationId) : null,
+				cancelReason
+		);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/message/dto/SlotConfirmedEventMessage.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/dto/SlotConfirmedEventMessage.java
@@ -1,0 +1,48 @@
+package com.teambind.springproject.message.dto;
+
+import com.teambind.springproject.room.event.event.SlotConfirmedEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 슬롯 예약 확정 이벤트 메시지 DTO.
+ * <p>
+ * Kafka 메시지로 전송될 때 사용되며, 모든 ID 필드는 String으로 직렬화된다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SlotConfirmedEventMessage {
+
+	private String topic;
+	private String eventType;
+	private String reservationId;
+	private LocalDateTime occurredAt;
+
+	/**
+	 * SlotConfirmedEvent로부터 메시지 DTO를 생성한다.
+	 * Long ID → String ID 변환
+	 */
+	public static SlotConfirmedEventMessage from(SlotConfirmedEvent event) {
+		return new SlotConfirmedEventMessage(
+				event.getTopic(),
+				event.getEventType(),
+				event.getReservationId() != null ? event.getReservationId().toString() : null,
+				event.getOccurredAt()
+		);
+	}
+
+	/**
+	 * 메시지 DTO를 SlotConfirmedEvent로 변환한다.
+	 * String ID → Long ID 변환
+	 */
+	public SlotConfirmedEvent toEvent() {
+		return SlotConfirmedEvent.of(
+				reservationId != null ? Long.parseLong(reservationId) : null
+		);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/message/dto/SlotGenerationRequestedEventMessage.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/dto/SlotGenerationRequestedEventMessage.java
@@ -1,0 +1,58 @@
+package com.teambind.springproject.message.dto;
+
+import com.teambind.springproject.room.event.event.SlotGenerationRequestedEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 슬롯 생성 요청 이벤트 메시지 DTO.
+ * <p>
+ * Kafka 메시지로 전송될 때 사용되며, 모든 ID 필드는 String으로 직렬화된다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SlotGenerationRequestedEventMessage {
+
+	private String topic;
+	private String eventType;
+	private String requestId;
+	private String roomId;
+	private LocalDate startDate;
+	private LocalDate endDate;
+	private LocalDateTime requestedAt;
+
+	/**
+	 * SlotGenerationRequestedEvent로부터 메시지 DTO를 생성한다.
+	 * Long ID → String ID 변환
+	 */
+	public static SlotGenerationRequestedEventMessage from(SlotGenerationRequestedEvent event) {
+		return new SlotGenerationRequestedEventMessage(
+				event.getTopic(),
+				event.getEventType(),
+				event.getRequestId(),
+				event.getRoomId() != null ? event.getRoomId().toString() : null,
+				event.getStartDate(),
+				event.getEndDate(),
+				event.getRequestedAt()
+		);
+	}
+
+	/**
+	 * 메시지 DTO를 SlotGenerationRequestedEvent로 변환한다.
+	 * String ID → Long ID 변환
+	 */
+	public SlotGenerationRequestedEvent toEvent() {
+		return SlotGenerationRequestedEvent.of(
+				requestId,
+				roomId != null ? Long.parseLong(roomId) : null,
+				startDate,
+				endDate
+		);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/message/dto/SlotReservedEventMessage.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/dto/SlotReservedEventMessage.java
@@ -1,0 +1,60 @@
+package com.teambind.springproject.message.dto;
+
+import com.teambind.springproject.room.event.event.SlotReservedEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * 슬롯 예약 대기 이벤트 메시지 DTO.
+ * <p>
+ * Kafka 메시지로 전송될 때 사용되며, 모든 ID 필드는 String으로 직렬화된다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SlotReservedEventMessage {
+
+	private String topic;
+	private String eventType;
+	private String roomId;
+	private LocalDate slotDate;
+	private List<LocalTime> startTimes;
+	private String reservationId;
+	private LocalDateTime occurredAt;
+
+	/**
+	 * SlotReservedEvent로부터 메시지 DTO를 생성한다.
+	 * Long ID → String ID 변환
+	 */
+	public static SlotReservedEventMessage from(SlotReservedEvent event) {
+		return new SlotReservedEventMessage(
+				event.getTopic(),
+				event.getEventType(),
+				event.getRoomId() != null ? event.getRoomId().toString() : null,
+				event.getSlotDate(),
+				event.getStartTimes(),
+				event.getReservationId() != null ? event.getReservationId().toString() : null,
+				event.getOccurredAt()
+		);
+	}
+
+	/**
+	 * 메시지 DTO를 SlotReservedEvent로 변환한다.
+	 * String ID → Long ID 변환
+	 */
+	public SlotReservedEvent toEvent() {
+		return SlotReservedEvent.of(
+				roomId != null ? Long.parseLong(roomId) : null,
+				slotDate,
+				startTimes,
+				reservationId != null ? Long.parseLong(reservationId) : null
+		);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/message/dto/SlotRestoredEventMessage.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/dto/SlotRestoredEventMessage.java
@@ -1,0 +1,51 @@
+package com.teambind.springproject.message.dto;
+
+import com.teambind.springproject.room.event.event.SlotRestoredEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 슬롯 복구 이벤트 메시지 DTO.
+ * <p>
+ * Kafka 메시지로 전송될 때 사용되며, 모든 ID 필드는 String으로 직렬화된다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SlotRestoredEventMessage {
+
+	private String topic;
+	private String eventType;
+	private String reservationId;
+	private String restoreReason;
+	private LocalDateTime occurredAt;
+
+	/**
+	 * SlotRestoredEvent로부터 메시지 DTO를 생성한다.
+	 * Long ID → String ID 변환
+	 */
+	public static SlotRestoredEventMessage from(SlotRestoredEvent event) {
+		return new SlotRestoredEventMessage(
+				event.getTopic(),
+				event.getEventType(),
+				event.getReservationId() != null ? event.getReservationId().toString() : null,
+				event.getRestoreReason(),
+				event.getOccurredAt()
+		);
+	}
+
+	/**
+	 * 메시지 DTO를 SlotRestoredEvent로 변환한다.
+	 * String ID → Long ID 변환
+	 */
+	public SlotRestoredEvent toEvent() {
+		return SlotRestoredEvent.of(
+				reservationId != null ? Long.parseLong(reservationId) : null,
+				restoreReason
+		);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/message/publish/EventPublisher.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/publish/EventPublisher.java
@@ -2,7 +2,9 @@ package com.teambind.springproject.message.publish;
 
 
 import com.teambind.springproject.common.util.json.JsonUtil;
+import com.teambind.springproject.message.dto.*;
 import com.teambind.springproject.message.event.Event;
+import com.teambind.springproject.room.event.event.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -12,9 +14,34 @@ import org.springframework.stereotype.Service;
 public class EventPublisher {
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 	private final JsonUtil jsonUtil;
-	
+
 	public void publish(Event event) {
-		String json = jsonUtil.toJson(event);
+		// Event를 Message DTO로 변환 (ID: Long → String)
+		Object messageDto = convertToMessage(event);
+
+		String json = jsonUtil.toJson(messageDto);
 		kafkaTemplate.send(event.getTopic(), json);
+	}
+
+	/**
+	 * Event를 Message DTO로 변환한다.
+	 * 모든 ID 필드가 Long → String으로 변환된다.
+	 */
+	private Object convertToMessage(Event event) {
+		if (event instanceof SlotReservedEvent) {
+			return SlotReservedEventMessage.from((SlotReservedEvent) event);
+		} else if (event instanceof SlotConfirmedEvent) {
+			return SlotConfirmedEventMessage.from((SlotConfirmedEvent) event);
+		} else if (event instanceof SlotCancelledEvent) {
+			return SlotCancelledEventMessage.from((SlotCancelledEvent) event);
+		} else if (event instanceof SlotRestoredEvent) {
+			return SlotRestoredEventMessage.from((SlotRestoredEvent) event);
+		} else if (event instanceof SlotGenerationRequestedEvent) {
+			return SlotGenerationRequestedEventMessage.from((SlotGenerationRequestedEvent) event);
+		} else if (event instanceof ClosedDateUpdateRequestedEvent) {
+			return ClosedDateUpdateRequestedEventMessage.from((ClosedDateUpdateRequestedEvent) event);
+		}
+
+		throw new IllegalArgumentException("Unknown event type: " + event.getClass().getName());
 	}
 }


### PR DESCRIPTION
## Summary
Kafka 메시지 발행 시 모든 ID 필드를 String으로 변환하고, 수신 시 Long으로 다시 변환하는 기능을 구현했습니다.

## 주요 변경사항

### 1. 이벤트 메시지 DTO 추가
- `SlotReservedEventMessage`: 슬롯 예약 대기 이벤트
- `SlotConfirmedEventMessage`: 슬롯 예약 확정 이벤트
- `SlotCancelledEventMessage`: 슬롯 취소 이벤트
- `SlotRestoredEventMessage`: 슬롯 복구 이벤트
- `SlotGenerationRequestedEventMessage`: 슬롯 생성 요청 이벤트
- `ClosedDateUpdateRequestedEventMessage`: 휴무일 업데이트 요청 이벤트

각 Message DTO는:
- 모든 ID 필드를 `String` 타입으로 선언
- `from(Event)`: Event → Message DTO 변환 (Long → String)
- `toEvent()`: Message DTO → Event 변환 (String → Long)

### 2. EventPublisher 수정
- Event를 Message DTO로 변환하여 Kafka에 발행
- ID 필드 자동 변환 (Long → String)

### 3. EventConsumer 수정
- Kafka 메시지를 Message DTO로 역직렬화
- Message DTO를 Event로 변환하여 핸들러에 전달
- ID 필드 자동 변환 (String → Long)

### 4. JsonUtil 개선
- `JavaTimeModule` 등록으로 Java 8 날짜/시간 타입 지원
- `WRITE_DATES_AS_TIMESTAMPS` 비활성화하여 ISO-8601 형식 사용

## 기술적 의사결정

### 도메인 모델 보호
- Event 클래스는 기존 Long 타입 유지
- 도메인 로직 변경 없음

### 명확한 경계
- 메시지 계층(Message DTO)과 도메인 계층(Event) 분리
- 타입 변환 책임을 Message DTO에 위임

### 타입 안전성
- 컴파일 타임에 변환 오류 감지 가능
- 명시적인 변환 로직으로 유지보수성 향상

## Test Plan
- [x] 빌드 성공 확인
- [ ] setupRoom API 호출 테스트
- [ ] Kafka 메시지 발행/수신 확인
- [ ] ID 변환 정상 동작 확인