### PR TITLE
[FEAT] RefundCompleted 이벤트 수신 및 슬롯 복구 처리

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/message/consume/EventConsumer.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/consume/EventConsumer.java
@@ -31,6 +31,7 @@ public class EventConsumer {
 		MESSAGE_TYPE_MAP.put("SlotConfirmed", SlotConfirmedEventMessage.class);
 		MESSAGE_TYPE_MAP.put("SlotCancelled", SlotCancelledEventMessage.class);
 		MESSAGE_TYPE_MAP.put("SlotRestored", SlotRestoredEventMessage.class);
+		MESSAGE_TYPE_MAP.put("RefundCompleted", RefundCompletedEventMessage.class);
 		MESSAGE_TYPE_MAP.put("SlotGenerationRequested", SlotGenerationRequestedEventMessage.class);
 		MESSAGE_TYPE_MAP.put("ClosedDateUpdateRequested", ClosedDateUpdateRequestedEventMessage.class);
 	}
@@ -44,7 +45,7 @@ public class EventConsumer {
 	 * @param message JSON 형식의 이벤트 메시지
 	 */
 	@KafkaListener(
-			topics = {"reservation-reserved", "reservation-confirmed", "reservation-cancelled", "reservation-restored", "slot-generation-requested", "closed-date-update-requested"},
+			topics = {"reservation-reserved", "reservation-confirmed", "reservation-cancelled", "reservation-restored", "refund-completed", "slot-generation-requested", "closed-date-update-requested"},
 			groupId = "room-operation-consumer-group"
 	)
 	public void consume(String message) {
@@ -68,8 +69,8 @@ public class EventConsumer {
 			// 4. Message DTO를 Event로 변환 (ID: String → Long)
 			Event event = convertToEvent(messageDto);
 
-			// 5. 해당 이벤트를 처리할 핸들러 찾기
-			EventHandler handler = findHandler(eventType);
+			// 5. 해당 이벤트를 처리할 핸들러 찾기 (변환된 이벤트 타입 기준)
+			EventHandler handler = findHandler(event.getEventTypeName());
 			if (handler == null) {
 				log.warn("No handler found for event type: {}", eventType);
 				return;
@@ -99,6 +100,8 @@ public class EventConsumer {
 			return ((SlotCancelledEventMessage) messageDto).toEvent();
 		} else if (messageDto instanceof SlotRestoredEventMessage) {
 			return ((SlotRestoredEventMessage) messageDto).toEvent();
+		} else if (messageDto instanceof RefundCompletedEventMessage) {
+			return ((RefundCompletedEventMessage) messageDto).toEvent();
 		} else if (messageDto instanceof SlotGenerationRequestedEventMessage) {
 			return ((SlotGenerationRequestedEventMessage) messageDto).toEvent();
 		} else if (messageDto instanceof ClosedDateUpdateRequestedEventMessage) {

--- a/springProject/src/main/java/com/teambind/springproject/message/dto/RefundCompletedEventMessage.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/dto/RefundCompletedEventMessage.java
@@ -1,0 +1,34 @@
+package com.teambind.springproject.message.dto;
+
+import com.teambind.springproject.room.event.event.SlotRestoredEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 환불 완료 이벤트 메시지 DTO.
+ * <p>
+ * Kafka 메시지로 수신되며, SlotRestoredEvent로 변환되어 슬롯 복구 처리된다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RefundCompletedEventMessage {
+
+	private String topic;
+	private String eventType;
+	private String reservationId;
+	private String occurredAt;
+
+	/**
+	 * 메시지 DTO를 SlotRestoredEvent로 변환한다.
+	 * 환불 완료 시 해당 예약의 슬롯을 복구한다.
+	 */
+	public SlotRestoredEvent toEvent() {
+		return SlotRestoredEvent.of(
+				reservationId,
+				"REFUND"
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- RefundCompleted 이벤트 수신 시 슬롯을 AVAILABLE 상태로 복구
- 기존 SlotRestoredEventHandler 재사용

## Changes
- `RefundCompletedEventMessage` DTO 추가
- `EventConsumer`에 refund-completed 토픽 구독 추가