### PR TITLE
[#55] Static 키워드 제거 및 Constructor Injection 적용

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/room/command/domain/service/TimeSlotManagementServiceImpl.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/command/domain/service/TimeSlotManagementServiceImpl.java
@@ -29,13 +29,16 @@ import java.util.stream.Collectors;
 public class TimeSlotManagementServiceImpl implements TimeSlotManagementService {
 	
 	private static final Logger log = LoggerFactory.getLogger(TimeSlotManagementServiceImpl.class);
-	@Value("${room.timeSlot.pending.expiration.minutes}")
-	private static int PENDING_EXPIRATION_MINUTES;
 
 	private final TimeSlotPort timeSlotPort;
+	private final int pendingExpirationMinutes;
 
-	public TimeSlotManagementServiceImpl(TimeSlotPort timeSlotPort) {
+	public TimeSlotManagementServiceImpl(
+			TimeSlotPort timeSlotPort,
+			@Value("${room.timeSlot.pending.expiration.minutes}") int pendingExpirationMinutes
+	) {
 		this.timeSlotPort = timeSlotPort;
+		this.pendingExpirationMinutes = pendingExpirationMinutes;
 	}
 	
 	@Override
@@ -100,7 +103,7 @@ public class TimeSlotManagementServiceImpl implements TimeSlotManagementService 
 	@Override
 	public int restoreExpiredPendingSlots() {
 		// Port를 통해 만료된 PENDING 슬롯 조회
-		List<RoomTimeSlot> expiredSlots = timeSlotPort.findExpiredPendingSlots(PENDING_EXPIRATION_MINUTES);
+		List<RoomTimeSlot> expiredSlots = timeSlotPort.findExpiredPendingSlots(pendingExpirationMinutes);
 
 		for (RoomTimeSlot slot : expiredSlots) {
 			// PENDING → AVAILABLE 상태로 변경 및 reservationId 제거


### PR DESCRIPTION
## 개요

Related to #49, #55

Static  필드를 Constructor Injection으로 변경하여 설정값이 올바르게 주입되도록 수정합니다.

## 문제점

현재 코드:
```java
@Value("${room.timeSlot.pending.expiration.minutes}")
private static int PENDING_EXPIRATION_MINUTES;  // ❌ 항상 0
```

**영향**:
- Spring은 static 필드에 의존성 주입을 하지 않음
- PENDING_EXPIRATION_MINUTES가 항상 0으로 유지
- PENDING 슬롯 만료 로직이 동작하지 않음

## 해결 방법

```java
private final int pendingExpirationMinutes;

public TimeSlotManagementServiceImpl(
    TimeSlotPort timeSlotPort,
    @Value("${room.timeSlot.pending.expiration.minutes}") int pendingExpirationMinutes
) {
    this.timeSlotPort = timeSlotPort;
    this.pendingExpirationMinutes = pendingExpirationMinutes;  // ✅ 설정값 주입
}
```

## 변경 사항

### 수정 파일
- `TimeSlotManagementServiceImpl.java`

### 주요 변경점
1. **필드 타입 변경**: `static int` → `final int`
2. **네이밍 변경**: `PENDING_EXPIRATION_MINUTES` → `pendingExpirationMinutes`
3. **생성자 주입**: `@Value` 어노테이션을 생성자 파라미터에 적용
4. **참조 업데이트**: 모든 메서드에서 새 필드명 사용

## 검증

- [x] 컴파일 성공
- [x] 코드 변경 완료
- [ ] 단위 테스트 (#56)
- [ ] 통합 테스트 (#57)

## Next Steps

1. 이 PR 머지 → `feature/49-fix-static-value-injection`
2. #56 시작 (단위 테스트 작성)
3. #57 시작 (통합 테스트 작성)
4. 최종 PR → `main`