### PR TITLE
[FEATURE] 결제 완료 이벤트 처리 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/message/consume/EventConsumer.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/consume/EventConsumer.java
@@ -30,6 +30,7 @@ public class EventConsumer {
 		MESSAGE_TYPE_MAP.put("SlotReserved", SlotReservedEventMessage.class);
 		MESSAGE_TYPE_MAP.put("SlotCancelled", SlotCancelledEventMessage.class);
 		MESSAGE_TYPE_MAP.put("SlotRestored", SlotRestoredEventMessage.class);
+		MESSAGE_TYPE_MAP.put("PaymentCompleted", PaymentCompletedEventMessage.class);
 		MESSAGE_TYPE_MAP.put("RefundCompleted", RefundCompletedEventMessage.class);
 		MESSAGE_TYPE_MAP.put("SlotGenerationRequested", SlotGenerationRequestedEventMessage.class);
 		MESSAGE_TYPE_MAP.put("ClosedDateUpdateRequested", ClosedDateUpdateRequestedEventMessage.class);
@@ -44,7 +45,7 @@ public class EventConsumer {
 	 * @param message JSON 형식의 이벤트 메시지
 	 */
 	@KafkaListener(
-			topics = {"reservation-reserved", "reservation-cancelled", "reservation-restored", "refund-completed", "slot-generation-requested", "closed-date-update-requested"},
+			topics = {"reservation-reserved", "reservation-cancelled", "reservation-restored", "payment-completed", "refund-completed", "slot-generation-requested", "closed-date-update-requested"},
 			groupId = "room-operation-consumer-group"
 	)
 	public void consume(String message) {
@@ -97,6 +98,8 @@ public class EventConsumer {
 			return ((SlotCancelledEventMessage) messageDto).toEvent();
 		} else if (messageDto instanceof SlotRestoredEventMessage) {
 			return ((SlotRestoredEventMessage) messageDto).toEvent();
+		} else if (messageDto instanceof PaymentCompletedEventMessage) {
+			return ((PaymentCompletedEventMessage) messageDto).toEvent();
 		} else if (messageDto instanceof RefundCompletedEventMessage) {
 			return ((RefundCompletedEventMessage) messageDto).toEvent();
 		} else if (messageDto instanceof SlotGenerationRequestedEventMessage) {

--- a/springProject/src/main/java/com/teambind/springproject/message/dto/PaymentCompletedEventMessage.java
+++ b/springProject/src/main/java/com/teambind/springproject/message/dto/PaymentCompletedEventMessage.java
@@ -1,0 +1,44 @@
+package com.teambind.springproject.message.dto;
+
+import com.teambind.springproject.room.event.event.PaymentCompletedEvent;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 결제 완료 이벤트 메시지 DTO.
+ * <p>
+ * Kafka 메시지로 수신되며, PaymentCompletedEvent로 변환되어 슬롯 확정 처리된다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PaymentCompletedEventMessage {
+
+	private String topic;
+	private String eventType;
+	private String paymentId;
+	private String reservationId;
+	private String orderId;
+	private String paymentKey;
+	private Long amount;
+	private String method;
+	private String paidAt;
+
+	/**
+	 * 메시지 DTO를 PaymentCompletedEvent로 변환한다.
+	 * 결제 완료 시 해당 예약의 슬롯을 확정한다.
+	 */
+	public PaymentCompletedEvent toEvent() {
+		return PaymentCompletedEvent.of(
+				paymentId,
+				reservationId,
+				orderId,
+				paymentKey,
+				amount,
+				method,
+				paidAt
+		);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/command/domain/service/TimeSlotManagementService.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/command/domain/service/TimeSlotManagementService.java
@@ -56,6 +56,15 @@ public interface TimeSlotManagementService {
 	void cancelSlot(Long roomId, java.time.LocalDate slotDate, java.time.LocalTime slotTime);
 	
 	/**
+	 * 예약 ID로 연관된 모든 슬롯을 확정한다.
+	 * <p>
+	 * 결제 완료 이벤트 처리 시 호출된다.
+	 *
+	 * @param reservationId 예약 ID
+	 */
+	void confirmSlotsByReservationId(Long reservationId);
+
+	/**
 	 * 예약 ID로 연관된 모든 슬롯을 취소한다.
 	 *
 	 * @param reservationId 예약 ID

--- a/springProject/src/main/java/com/teambind/springproject/room/command/domain/service/TimeSlotManagementServiceImpl.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/command/domain/service/TimeSlotManagementServiceImpl.java
@@ -85,6 +85,26 @@ public class TimeSlotManagementServiceImpl implements TimeSlotManagementService 
 	}
 	
 	@Override
+	public void confirmSlotsByReservationId(Long reservationId) {
+		// Port를 통해 예약 ID로 슬롯 조회
+		List<RoomTimeSlot> slots = timeSlotPort.findByReservationId(reservationId);
+
+		if (slots.isEmpty()) {
+			log.warn("No slots found for reservationId={}", reservationId);
+			return;
+		}
+
+		for (RoomTimeSlot slot : slots) {
+			// PENDING → RESERVED 상태 전환
+			slot.confirm();
+		}
+
+		timeSlotPort.saveAll(slots);
+
+		log.info("Confirmed {} slots for reservationId={}", slots.size(), reservationId);
+	}
+
+	@Override
 	public void cancelSlotsByReservationId(Long reservationId) {
 		// Port를 통해 예약 ID로 슬롯 조회
 		List<RoomTimeSlot> slots = timeSlotPort.findByReservationId(reservationId);

--- a/springProject/src/main/java/com/teambind/springproject/room/event/event/PaymentCompletedEvent.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/event/event/PaymentCompletedEvent.java
@@ -1,0 +1,72 @@
+package com.teambind.springproject.room.event.event;
+
+import com.teambind.springproject.message.event.Event;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 결제 완료 이벤트.
+ * <p>
+ * Payment 도메인에서 발행한 결제 완료 이벤트를 Room 도메인에서 수신하여
+ * 해당 예약의 슬롯을 PENDING → RESERVED 상태로 확정한다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentCompletedEvent extends Event {
+
+	private static final String TOPIC = "payment-completed";
+	private static final String EVENT_TYPE = "PaymentCompleted";
+
+	private String paymentId;
+	private String reservationId;
+	private String orderId;
+	private String paymentKey;
+	private Long amount;
+	private String method;
+	private String paidAt;
+
+	private PaymentCompletedEvent(
+			String paymentId,
+			String reservationId,
+			String orderId,
+			String paymentKey,
+			Long amount,
+			String method,
+			String paidAt
+	) {
+		super(TOPIC, EVENT_TYPE);
+		this.paymentId = paymentId;
+		this.reservationId = reservationId;
+		this.orderId = orderId;
+		this.paymentKey = paymentKey;
+		this.amount = amount;
+		this.method = method;
+		this.paidAt = paidAt;
+	}
+
+	public static PaymentCompletedEvent of(
+			String paymentId,
+			String reservationId,
+			String orderId,
+			String paymentKey,
+			Long amount,
+			String method,
+			String paidAt
+	) {
+		return new PaymentCompletedEvent(
+				paymentId,
+				reservationId,
+				orderId,
+				paymentKey,
+				amount,
+				method,
+				paidAt
+		);
+	}
+
+	@Override
+	public String getEventTypeName() {
+		return EVENT_TYPE;
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/room/event/handler/PaymentCompletedEventHandler.java
+++ b/springProject/src/main/java/com/teambind/springproject/room/event/handler/PaymentCompletedEventHandler.java
@@ -1,0 +1,57 @@
+package com.teambind.springproject.room.event.handler;
+
+import com.teambind.springproject.message.handler.EventHandler;
+import com.teambind.springproject.room.command.domain.service.TimeSlotManagementService;
+import com.teambind.springproject.room.event.event.PaymentCompletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 결제 완료 이벤트 핸들러.
+ * <p>
+ * Hexagonal Architecture 적용:
+ * - Infrastructure Layer의 Repository를 직접 참조하지 않음
+ * - Domain Service를 통한 간접 참조로 계층 격리 유지
+ * <p>
+ * 해당 예약의 모든 슬롯을 PENDING → RESERVED 상태로 전환한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCompletedEventHandler implements EventHandler<PaymentCompletedEvent> {
+
+	private final TimeSlotManagementService timeSlotManagementService;
+
+	@Override
+	@Transactional
+	public void handle(PaymentCompletedEvent event) {
+		log.info("Processing PaymentCompletedEvent: paymentId={}, reservationId={}, orderId={}, amount={}",
+				event.getPaymentId(), event.getReservationId(), event.getOrderId(), event.getAmount());
+
+		try {
+			// String → Long 변환
+			Long reservationId = Long.parseLong(event.getReservationId());
+
+			// Domain Service를 통한 슬롯 확정 (트랜잭션 원자성 보장)
+			timeSlotManagementService.confirmSlotsByReservationId(reservationId);
+
+			log.info("PaymentCompletedEvent processed successfully: paymentId={}, reservationId={}, amount={}",
+					event.getPaymentId(), reservationId, event.getAmount());
+
+		} catch (NumberFormatException e) {
+			log.error("Invalid reservationId format: reservationId={}", event.getReservationId(), e);
+			throw new IllegalArgumentException("Invalid reservationId format: " + event.getReservationId(), e);
+		} catch (Exception e) {
+			log.error("Failed to process PaymentCompletedEvent: paymentId={}, reservationId={}, reason={}",
+					event.getPaymentId(), event.getReservationId(), e.getMessage(), e);
+			throw e; // Re-throw for transaction rollback
+		}
+	}
+
+	@Override
+	public String getSupportedEventType() {
+		return "PaymentCompleted";
+	}
+}


### PR DESCRIPTION
## Summary
Payment 도메인에서 발행한 결제 완료 이벤트를 Room 도메인에서 수신하여
해당 예약의 모든 슬롯을 PENDING → RESERVED 상태로 확정하는 기능을 구현했습니다.

## 변경 사항

### 신규 파일
- `PaymentCompletedEventMessage.java` - 결제 완료 이벤트 메시지 DTO
- `PaymentCompletedEvent.java` - 결제 완료 이벤트 클래스
- `PaymentCompletedEventHandler.java` - 결제 완료 이벤트 핸들러

### 수정된 파일
- `TimeSlotManagementService.java` / `TimeSlotManagementServiceImpl.java`
  - `confirmSlotsByReservationId(Long reservationId)` 메서드 추가
  - 예약 ID로 모든 슬롯을 PENDING → RESERVED 상태로 확정

- `EventConsumer.java`
  - PaymentCompletedEventMessage 매핑 추가
  - "payment-completed" 토픽 구독 추가
  - convertToEvent()에 PaymentCompletedEvent 변환 로직 추가

## 이벤트 구조
```json
{
  "paymentId": "PAY_20231125_001",
  "reservationId": "RSV_20231125_001",
  "orderId": "ORD_20231125_001",
  "paymentKey": "toss_payment_key_123456",
  "amount": 50000,
  "method": "CARD",
  "paidAt": "2025-11-25T14:30:00"
}
```

## 처리 흐름
1. Payment 도메인에서 `payment-completed` 토픽에 이벤트 발행
2. Room 도메인의 `EventConsumer`가 이벤트 수신
3. `PaymentCompletedEventHandler`가 이벤트 처리
4. `TimeSlotManagementService.confirmSlotsByReservationId()` 호출
5. 해당 예약의 모든 슬롯을 PENDING → RESERVED로 확정

## 아키텍처
- Hexagonal Architecture 준수
- Domain Service를 통한 슬롯 확정 처리
- @Transactional로 원자성 보장
- 멱등성 고려 (reservationId로 중복 처리 방지)

## Test plan
- [x] 메인 소스 컴파일 성공
- [ ] 단위 테스트 작성
- [ ] 통합 테스트 작성
- [ ] Payment 도메인과 연동 테스트