### PR TITLE
[FIX] RoomOperatingPolicy.create() SlotUnit 파라미터 추가에 따른 테스트 수정

### DIFF
--- a/springProject/src/test/java/com/teambind/springproject/room/command/application/ClosedDateSetupApplicationServiceTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/room/command/application/ClosedDateSetupApplicationServiceTest.java
@@ -10,6 +10,7 @@ import com.teambind.springproject.room.entity.ClosedDateUpdateRequest;
 import com.teambind.springproject.room.entity.RoomOperatingPolicy;
 import com.teambind.springproject.room.entity.enums.GenerationStatus;
 import com.teambind.springproject.room.entity.enums.RecurrencePattern;
+import com.teambind.springproject.room.entity.enums.SlotUnit;
 import com.teambind.springproject.room.entity.vo.WeeklySlotSchedule;
 import com.teambind.springproject.room.entity.vo.WeeklySlotTime;
 import com.teambind.springproject.room.event.event.ClosedDateUpdateRequestedEvent;
@@ -71,7 +72,7 @@ class ClosedDateSetupApplicationServiceTest {
 				WeeklySlotTime.of(DayOfWeek.MONDAY, LocalTime.of(10, 0))
 		);
 		WeeklySlotSchedule schedule = WeeklySlotSchedule.of(slotTimes);
-		policy = RoomOperatingPolicy.create(roomId, schedule, RecurrencePattern.EVERY_WEEK, List.of());
+		policy = RoomOperatingPolicy.create(roomId, schedule, RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR, List.of());
 		
 		// 휴무일 설정 요청: 2025-01-15 하루 종일 휴무
 		ClosedDateDto closedDateDto = new ClosedDateDto(

--- a/springProject/src/test/java/com/teambind/springproject/room/command/application/RoomSetupApplicationServiceTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/room/command/application/RoomSetupApplicationServiceTest.java
@@ -10,6 +10,7 @@ import com.teambind.springproject.room.entity.RoomOperatingPolicy;
 import com.teambind.springproject.room.entity.SlotGenerationRequest;
 import com.teambind.springproject.room.entity.enums.GenerationStatus;
 import com.teambind.springproject.room.entity.enums.RecurrencePattern;
+import com.teambind.springproject.room.entity.enums.SlotUnit;
 import com.teambind.springproject.room.event.event.SlotGenerationRequestedEvent;
 import com.teambind.springproject.room.query.dto.RoomSetupResponse;
 import com.teambind.springproject.room.query.dto.SlotGenerationStatusResponse;
@@ -70,7 +71,7 @@ class RoomSetupApplicationServiceTest {
 				List.of(LocalTime.of(9, 0), LocalTime.of(10, 0))
 		);
 		
-		setupRequest = new RoomOperatingPolicySetupRequest(roomId, List.of(slotDto));
+		setupRequest = new RoomOperatingPolicySetupRequest(roomId, List.of(slotDto), SlotUnit.HOUR);
 		
 		log.info("=== 테스트 데이터 초기화 ===");
 		log.info("- roomId: {}", roomId);
@@ -156,7 +157,7 @@ class RoomSetupApplicationServiceTest {
 		
 		// Given
 		log.info("[Given] Mock 동작 설정");
-		RoomOperatingPolicySetupRequest emptyRequest = new RoomOperatingPolicySetupRequest(roomId, List.of());
+		RoomOperatingPolicySetupRequest emptyRequest = new RoomOperatingPolicySetupRequest(roomId, List.of(), SlotUnit.HOUR);
 		log.info("[Given] - 빈 슬롯 목록으로 요청 생성");
 		
 		RoomOperatingPolicy savedPolicy = mock(RoomOperatingPolicy.class);
@@ -281,7 +282,7 @@ class RoomSetupApplicationServiceTest {
 		
 		RoomOperatingPolicySetupRequest multiSlotRequest = new RoomOperatingPolicySetupRequest(
 				roomId,
-				List.of(mondaySlot, tuesdaySlot)
+				List.of(mondaySlot, tuesdaySlot), SlotUnit.HOUR
 		);
 		log.info("[Given] - 여러 요일/시간 슬롯 요청 생성");
 		log.info("[Given]   - Monday: 09:00, 10:00, 11:00");

--- a/springProject/src/test/java/com/teambind/springproject/room/command/domain/service/TimeSlotGenerationServiceImplTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/room/command/domain/service/TimeSlotGenerationServiceImplTest.java
@@ -158,7 +158,6 @@ class TimeSlotGenerationServiceImplTest {
 		LocalDate endDate = LocalDate.of(2025, 1, 22);   // 수요일 (3일)
 		
 		when(operatingPolicyPort.findByRoomId(roomId)).thenReturn(Optional.of(policy));
-		when(placeInfoApiClient.getSlotUnit(roomId)).thenReturn(slotUnit);
 		
 		List<RoomTimeSlot> slotsPerDay = List.of(
 				RoomTimeSlot.available(roomId, startDate, LocalTime.of(9, 0)),

--- a/springProject/src/test/java/com/teambind/springproject/room/command/domain/service/TimeSlotManagementServiceImplTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/room/command/domain/service/TimeSlotManagementServiceImplTest.java
@@ -2,6 +2,8 @@ package com.teambind.springproject.room.command.domain.service;
 
 import com.teambind.springproject.common.exceptions.domain.SlotNotFoundException;
 import com.teambind.springproject.room.domain.port.TimeSlotPort;
+import com.teambind.springproject.room.domain.port.ClosedDateUpdateRequestPort;
+import com.teambind.springproject.room.domain.port.OperatingPolicyPort;
 import com.teambind.springproject.room.entity.RoomTimeSlot;
 import com.teambind.springproject.room.entity.enums.SlotStatus;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +39,10 @@ class TimeSlotManagementServiceImplTest {
 	
 	@Mock
 	private TimeSlotPort timeSlotPort;
+	@Mock
+	private OperatingPolicyPort operatingPolicyPort;
+	@Mock
+	private ClosedDateUpdateRequestPort closedDateUpdateRequestPort;
 
 	private TimeSlotManagementServiceImpl service;
 
@@ -51,7 +57,7 @@ class TimeSlotManagementServiceImplTest {
 	@BeforeEach
 	void setUp() {
 		// Service 생성 (Constructor Injection)
-		service = new TimeSlotManagementServiceImpl(timeSlotPort, PENDING_EXPIRATION_MINUTES);
+		service = new TimeSlotManagementServiceImpl(timeSlotPort, operatingPolicyPort, closedDateUpdateRequestPort, PENDING_EXPIRATION_MINUTES);
 
 		roomId = 100L;
 		slotDate = LocalDate.of(2025, 1, 15);

--- a/springProject/src/test/java/com/teambind/springproject/room/entity/RoomOperatingPolicyTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/room/entity/RoomOperatingPolicyTest.java
@@ -104,7 +104,7 @@ class RoomOperatingPolicyTest {
 			
 			// When
 			RoomOperatingPolicy policy =
-					RoomOperatingPolicy.create(roomId, schedule, recurrence, closedDates);
+					RoomOperatingPolicy.create(roomId, schedule, recurrence, SlotUnit.HOUR, closedDates);
 			
 			// Then
 			assertThat(policy.getRoomId()).isEqualTo(roomId);
@@ -125,7 +125,7 @@ class RoomOperatingPolicyTest {
 			assertThatThrownBy(
 					() ->
 							RoomOperatingPolicy.create(
-									null, schedule, RecurrencePattern.EVERY_WEEK, Collections.emptyList()))
+									null, schedule, RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR, Collections.emptyList()))
 					.isInstanceOf(NullPointerException.class)
 					.hasMessageContaining("roomId must not be null");
 		}
@@ -140,7 +140,7 @@ class RoomOperatingPolicyTest {
 			assertThatThrownBy(
 					() ->
 							RoomOperatingPolicy.create(
-									roomId, null, RecurrencePattern.EVERY_WEEK, Collections.emptyList()))
+									roomId, null, RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR, Collections.emptyList()))
 					.isInstanceOf(NullPointerException.class)
 					.hasMessageContaining("weeklySchedule must not be null");
 		}
@@ -154,7 +154,7 @@ class RoomOperatingPolicyTest {
 			
 			// When & Then
 			assertThatThrownBy(
-					() -> RoomOperatingPolicy.create(roomId, schedule, null, Collections.emptyList()))
+					() -> RoomOperatingPolicy.create(roomId, schedule, null, SlotUnit.HOUR, Collections.emptyList()))
 					.isInstanceOf(NullPointerException.class)
 					.hasMessageContaining("recurrence must not be null");
 		}
@@ -325,7 +325,7 @@ class RoomOperatingPolicyTest {
 					RoomOperatingPolicy.create(
 							101L,
 							WeeklySlotSchedule.of(slotTimes),
-							RecurrencePattern.EVERY_WEEK,
+							RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR,
 							List.of(lunchBreak));
 			
 			// When

--- a/springProject/src/test/java/com/teambind/springproject/room/infrastructure/persistence/OperatingPolicyJpaAdapterIntegrationTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/room/infrastructure/persistence/OperatingPolicyJpaAdapterIntegrationTest.java
@@ -5,6 +5,7 @@ import com.teambind.springproject.config.TestRedisConfig;
 import com.teambind.springproject.room.domain.port.OperatingPolicyPort;
 import com.teambind.springproject.room.entity.RoomOperatingPolicy;
 import com.teambind.springproject.room.entity.enums.RecurrencePattern;
+import com.teambind.springproject.room.entity.enums.SlotUnit;
 import com.teambind.springproject.room.entity.vo.WeeklySlotSchedule;
 import com.teambind.springproject.room.entity.vo.WeeklySlotTime;
 import lombok.extern.slf4j.Slf4j;
@@ -69,7 +70,7 @@ class OperatingPolicyJpaAdapterIntegrationTest {
 		RoomOperatingPolicy policy = RoomOperatingPolicy.create(
 				roomId,
 				schedule,
-				RecurrencePattern.EVERY_WEEK,
+				RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR,
 				List.of()
 		);
 		log.info("[Given] - 생성된 정책: roomId={}, recurrence={}",
@@ -116,7 +117,7 @@ class OperatingPolicyJpaAdapterIntegrationTest {
 		RoomOperatingPolicy policy = RoomOperatingPolicy.create(
 				roomId,
 				schedule,
-				RecurrencePattern.EVERY_WEEK,
+				RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR,
 				List.of()
 		);
 		operatingPolicyPort.save(policy);
@@ -183,13 +184,13 @@ class OperatingPolicyJpaAdapterIntegrationTest {
 		WeeklySlotSchedule schedule3 = WeeklySlotSchedule.of(slotTimes3);
 		
 		RoomOperatingPolicy policy1 = RoomOperatingPolicy.create(
-				room1Id, schedule1, RecurrencePattern.EVERY_WEEK, List.of()
+				room1Id, schedule1, RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR, List.of()
 		);
 		RoomOperatingPolicy policy2 = RoomOperatingPolicy.create(
-				room2Id, schedule2, RecurrencePattern.ODD_WEEK, List.of()
+				room2Id, schedule2, RecurrencePattern.ODD_WEEK, SlotUnit.HOUR, List.of()
 		);
 		RoomOperatingPolicy policy3 = RoomOperatingPolicy.create(
-				room3Id, schedule3, RecurrencePattern.EVEN_WEEK, List.of()
+				room3Id, schedule3, RecurrencePattern.EVEN_WEEK, SlotUnit.HOUR, List.of()
 		);
 		
 		operatingPolicyPort.save(policy1);
@@ -234,7 +235,7 @@ class OperatingPolicyJpaAdapterIntegrationTest {
 		RoomOperatingPolicy policy = RoomOperatingPolicy.create(
 				roomId,
 				schedule,
-				RecurrencePattern.EVERY_WEEK,
+				RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR,
 				List.of()
 		);
 		operatingPolicyPort.save(policy);
@@ -281,7 +282,7 @@ class OperatingPolicyJpaAdapterIntegrationTest {
 		RoomOperatingPolicy policy = RoomOperatingPolicy.create(
 				roomId,
 				schedule,
-				RecurrencePattern.EVERY_WEEK,
+				RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR,
 				List.of()
 		);
 		RoomOperatingPolicy savedPolicy = operatingPolicyPort.save(policy);

--- a/springProject/src/test/java/com/teambind/springproject/room/service/integration/TimeSlotGenerationServiceIntegrationTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/room/service/integration/TimeSlotGenerationServiceIntegrationTest.java
@@ -74,7 +74,7 @@ class TimeSlotGenerationServiceIntegrationTest {
 		policy = RoomOperatingPolicy.create(
 				roomId,
 				schedule,
-				RecurrencePattern.EVERY_WEEK,
+				RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR,
 				List.of()
 		);
 		
@@ -284,7 +284,7 @@ class TimeSlotGenerationServiceIntegrationTest {
 		RoomOperatingPolicy policy2 = RoomOperatingPolicy.create(
 				room2Id,
 				WeeklySlotSchedule.of(room2Times),
-				RecurrencePattern.EVERY_WEEK,
+				RecurrencePattern.EVERY_WEEK, SlotUnit.HOUR,
 				List.of()
 		);
 		policyRepository.save(policy2);


### PR DESCRIPTION
## 문제
이전 리팩터링 (#47)에서 `RoomOperatingPolicy.create()` 메서드에 `SlotUnit` 파라미터가 추가되었으나, 테스트 파일들이 업데이트되지 않아 34개 컴파일 에러 발생

## 해결 방법
모든 `RoomOperatingPolicy.create()` 호출에 `SlotUnit.HOUR` 파라미터 추가

## 수정된 파일 (7개)

### 1. RoomOperatingPolicyTest.java
- `create()` 호출 5곳에 `SlotUnit.HOUR` 파라미터 추가

### 2. RoomSetupApplicationServiceTest.java
- `RoomOperatingPolicySetupRequest` 생성자 3곳 수정 (SlotUnit 파라미터 추가)
- `import SlotUnit` 추가

### 3. ClosedDateSetupApplicationServiceTest.java
- `create()` 호출 1곳 수정
- `import SlotUnit` 추가

### 4. TimeSlotGenerationServiceIntegrationTest.java
- `create()` 호출 2곳 수정

### 5. OperatingPolicyJpaAdapterIntegrationTest.java
- `create()` 호출 7곳 수정
- `import SlotUnit` 추가

### 6. TimeSlotManagementServiceImplTest.java
- 생성자 파라미터 추가: `operatingPolicyPort`, `closedDateUpdateRequestPort`
- Mock 선언 추가
- Import 추가

### 7. TimeSlotGenerationServiceImplTest.java  
- `PlaceInfoApiClient` Mock 제거 (이전 리팩터링에서 이미 삭제됨)

## 테스트 결과
✅ `./gradlew compileTestJava`: **BUILD SUCCESSFUL**

## 관련 이슈
- 이전 PR: #47 (PlaceInfoApiClient 제거 및 SlotUnit 내부 관리로 통합)